### PR TITLE
Merchant Spawning Changes

### DIFF
--- a/scarymazegame/Assets/Scripts/AleixisScripts/RandomSpawning.cs
+++ b/scarymazegame/Assets/Scripts/AleixisScripts/RandomSpawning.cs
@@ -5,7 +5,9 @@ using UnityEngine;
 public class RandomSpawning : MonoBehaviour
 {
     [Header("Variables")]
-    float ElapsedTime = 0f;
+    float ElapsedTime = 0.0f;
+    float ResetTime = 3.0f;
+    bool ResetStart = false;
 
     [Header("Serialized Fields")] //serializes the fields
     [SerializeField] private Transform Merchant;
@@ -16,6 +18,8 @@ public class RandomSpawning : MonoBehaviour
     {
         if (other.CompareTag("Spawner")) //When asset hits trigger, the script compares the tag of the trigger to see if it is a spawner
         {
+            ResetStart = false;
+            ElapsedTime = 0.0f;
             Merchant.transform.position = SpawnPoint.transform.position; //Takes the position of the merchant then transforms it (changes it) to the transform of the selected position
             Physics.SyncTransforms(); //Syncs transforms so that nothing breaks, unity does a lot of the damage control
         }
@@ -25,13 +29,8 @@ public class RandomSpawning : MonoBehaviour
     {
         if (other.CompareTag("Spawner"))
         {
-            ElapsedTime = 0;
+            ResetStart = true;
             StartCoroutine(ElapsedTimer());
-
-            if (ElapsedTime > 3)
-            {
-                Merchant.transform.position = DefaultSpawn.transform.position;
-            }
         }
     }
 
@@ -43,11 +42,29 @@ public class RandomSpawning : MonoBehaviour
     void Update()
     {
         Debug.Log(ElapsedTime);
+        Debug.Log(ResetStart);
     }
 
     private IEnumerator ElapsedTimer()
     {
-        ElapsedTime += Time.deltaTime;
+        if(ResetStart)
+        {
+            while(ElapsedTime < ResetTime && ResetStart)
+            {
+                ElapsedTime++;
+                yield return new WaitForSeconds(1f); //Waits for 1 second before adding on to ElapsedTime
+            }
+        }
+        else
+        {
+            ResetStart = false;
+            yield return null;
+        }
+
+        if (ElapsedTime >= ResetTime)
+        {
+            Merchant.transform.position = DefaultSpawn.transform.position;
+        }
 
         yield return null;
     }


### PR DESCRIPTION
Changed a part of the script so that the merchant teleports in and stays there until the player leaves the trigger area. if the player goes back into the area, it will extend the time before the merchant teleports back to default spot (20 minutes~)